### PR TITLE
Require Java 8 in POM

### DIFF
--- a/java_skeleton/pom.xml
+++ b/java_skeleton/pom.xml
@@ -12,8 +12,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Build fails because source contains Java 8 features and README says 8
is required.
