### PR TITLE
Update README.md

### DIFF
--- a/python_skeleton/README.md
+++ b/python_skeleton/README.md
@@ -13,6 +13,10 @@ On Mac:
 
     brew install libffi
     
+On CentOS:
+
+    yum install libffi-devel
+        
 On Ubuntu:
 
     apt-get install libffi-dev libsasl2-dev


### PR DESCRIPTION
Add CentOS instructions to install libffi-devel before the pip command
